### PR TITLE
Fix issues with linked sub-objects, and cleanup

### DIFF
--- a/src/tasks/minions/pickpocketActivity.ts
+++ b/src/tasks/minions/pickpocketActivity.ts
@@ -7,7 +7,7 @@ import { ClientSettings } from '../../lib/settings/types/ClientSettings';
 import { Pickpockable, Pickpocketables } from '../../lib/skilling/skills/thieving/stealables';
 import { SkillsEnum } from '../../lib/skilling/types';
 import { PickpocketActivityTaskOptions } from '../../lib/types/minions';
-import { rogueOutfitPercentBonus, skillingPetChance, updateGPTrackSetting } from '../../lib/util';
+import { rogueOutfitPercentBonus, skillingPetDropRate, updateGPTrackSetting } from '../../lib/util';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
 
 export function calcLootXPPickpocketing(
@@ -55,8 +55,9 @@ export default class extends Task {
 		let rogueOutfitBoostActivated = false;
 
 		const loot = new Bank();
+		const adjustedLootTable = skillingPetDropRate(user, SkillsEnum.Thieving, npc.table, 'Rocky') as LootTable;
 		for (let i = 0; i < successfulQuantity; i++) {
-			const lootItems = (skillingPetChance(user, SkillsEnum.Thieving, npc.table, 'Rocky') as LootTable).roll();
+			const lootItems = adjustedLootTable.roll();
 			if (randInt(1, 100) <= rogueOutfitPercentBonus(user)) {
 				rogueOutfitBoostActivated = true;
 				const doubledLoot = lootItems.multiply(2);


### PR DESCRIPTION
### Description:

Make some vars/functions easier to understand
Fixes an issue where updating the cloned LootTable would affect the original.
Moves the generation of the custom LootTable outside the for() loop.

-   [x] I have tested all my changes thoroughly.
